### PR TITLE
Add a new test dependency: `pytest-randomly`

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 black==21.6b0
 mypy==0.910
 mkdocs==1.2.1
-pytest-cov==2.12.1
 radon==5.0.1
+pytest-cov==2.12.1
+pytest-randomly==3.8.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,1 +1,2 @@
 pytest-cov==2.12.1
+pytest-randomly==3.8.0


### PR DESCRIPTION
This enables tests to run out of order so that there are no hidden
ordering dependencies between tests.