### PR TITLE
Remove the python nightly version CI run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,16 @@ dist: xenial
 language: python
 python:
   - "3.9"
-  - "nightly"
 
 before_install:
     - python3 -m pip install -U pip
+    - pip install -U setuptools
+    - pip install -U wheel
 
 install:
   - pip install -r requirements-test.txt
 
-script: pytest
+script: pytest --cov=hasdrubal
 
 after_success:
   - codecov


### PR DESCRIPTION
It's not necessary since I am only working with python 3.9.3 and I don't have any plans to deploy the app on this version anyway.